### PR TITLE
Potential fix for code scanning alert no. 3: Code injection

### DIFF
--- a/server.js
+++ b/server.js
@@ -149,14 +149,13 @@ app.get('/api/robots', (req, res) => {
     res.json(robots);
 });
 
-// Intentionally vulnerable endpoint for demo
+// Export endpoint
 app.get('/api/export/:format', (req, res) => {
     const format = req.params.format;
 
-    // Intentionally unsafe eval for demo purposes
     try {
-        const exportFunction = eval(`(function() { return "Exporting data as ${format}"; })`);
-        res.json({ message: exportFunction() });
+        const message = `Exporting data as ${format}`;
+        res.json({ message });
     } catch (error) {
         res.status(400).json({ error: 'Invalid format' });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/timothywarner-org/globomantics-robot-fleet/security/code-scanning/3](https://github.com/timothywarner-org/globomantics-robot-fleet/security/code-scanning/3)

In general, to fix code injection issues you must avoid evaluating strings that include user input as code. Instead, implement the required logic directly in JavaScript, or use safe lookup/dispatch tables. If you need dynamic behavior, use data-driven branching rather than `eval`, `Function`, or similar.

For this endpoint, the functionality is simply to return a string `"Exporting data as ${format}"`. There is no need for `eval` or for constructing a function from a string. We can generate this message directly and send it, preserving the same observable behavior for callers (same JSON shape, same message content) while eliminating the code injection sink.

Concretely:

- In `server.js`, in the `/api/export/:format` handler (lines 153–162), remove the `eval` call and the dynamically constructed function string.
- Replace it with direct string interpolation using `format` and respond via `res.json({ message: ... })`.
- You can still keep a `try/catch` if you want to preserve the structure, but it is no longer needed for `eval` errors. To keep behavior close, we can leave the try/catch in place or simplify it; I’ll keep it but make it trivial.

No new imports or helper methods are required; just remove the `eval` usage and compute the message directly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
